### PR TITLE
Add crypto trading journal webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Crypto Trading Journal & Strategy Guide</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="hero">
+    <div class="hero__overlay"></div>
+    <div class="hero__content">
+      <h1>Crypto Trading Journal &amp; Strategy Guide</h1>
+      <p>Track every trade, refine your edge, and grow with disciplined execution.</p>
+      <a href="#journal" class="btn">Get Started</a>
+    </div>
+  </header>
+
+  <nav class="nav">
+    <a href="#mindset">Mindset</a>
+    <a href="#framework">Trading Framework</a>
+    <a href="#strategies">Strategies</a>
+    <a href="#journal">Trading Journal</a>
+    <a href="#metrics">Performance Metrics</a>
+    <a href="#review">Review Checklist</a>
+    <a href="#resources">Resources</a>
+  </nav>
+
+  <main>
+    <section id="mindset" class="card">
+      <h2>Trader Mindset &amp; Risk Principles</h2>
+      <ul>
+        <li><strong>Capital preservation first:</strong> risk 1&ndash;2% of equity per trade. Focus on staying in the game.</li>
+        <li><strong>Plan the trade, trade the plan:</strong> only act on predefined setups with entry, stop, and target.</li>
+        <li><strong>Probability mindset:</strong> judge decisions by process quality, not individual outcomes.</li>
+        <li><strong>Detach from PnL:</strong> avoid revenge trading, track emotional state in your journal.</li>
+        <li><strong>Continuous improvement:</strong> review results weekly, adapt sizing to volatility and performance.</li>
+      </ul>
+    </section>
+
+    <section id="framework" class="card">
+      <h2>Daily Trading Framework</h2>
+      <div class="grid two">
+        <div>
+          <h3>Pre-Market Routine</h3>
+          <ol>
+            <li>Review macro news, crypto catalysts, and on-chain flows.</li>
+            <li>Mark support/resistance, trend context, and liquidity pools on key charts.</li>
+            <li>Update watchlist with bias (bullish, bearish, neutral) and planned setups.</li>
+            <li>Check risk dashboard: open exposure, drawdown limits, volatility regime.</li>
+            <li>Define execution plan: alerts, position sizing, and invalidation levels.</li>
+          </ol>
+        </div>
+        <div>
+          <h3>Post-Market Routine</h3>
+          <ol>
+            <li>Log trades with screenshots, rationale, and emotions.</li>
+            <li>Tag trades by strategy to measure edge quality.</li>
+            <li>Update performance metrics and risk exposure.</li>
+            <li>Identify mistakes or standout executions.</li>
+            <li>Plan adjustments for tomorrow (e.g., reduce size, avoid certain sessions).</li>
+          </ol>
+        </div>
+      </div>
+    </section>
+
+    <section id="strategies" class="card">
+      <h2>Core Trading Strategies</h2>
+      <article class="strategy">
+        <h3>1. Trend Continuation (Break &amp; Retest)</h3>
+        <p><strong>Market context:</strong> Strong directional move with higher highs/lows (bull) or lower lows/highs (bear).</p>
+        <p><strong>Execution:</strong> Enter on retest of prior structure or 21EMA with confirmation (volume spike, momentum oscillator).</p>
+        <p><strong>Risk:</strong> Stop beyond invalidation structure; target 2R&ndash;3R or trail using swing highs/lows.</p>
+        <p><strong>Notes:</strong> Avoid during consolidations; track success rate vs. market regime.</p>
+      </article>
+      <article class="strategy">
+        <h3>2. Range Reversion</h3>
+        <p><strong>Market context:</strong> Sideways range with clear boundaries and volume tapering.</p>
+        <p><strong>Execution:</strong> Fade moves into range extremes using confirmation (rejection wick, divergence).</p>
+        <p><strong>Risk:</strong> Stop outside the range; scale out near midline and opposite boundary.</p>
+        <p><strong>Notes:</strong> Cancel trade if breakout retest holds. Avoid trading just before major news.</p>
+      </article>
+      <article class="strategy">
+        <h3>3. Breakout Momentum</h3>
+        <p><strong>Market context:</strong> Consolidation leading to volatility contraction (e.g., Bollinger squeeze).</p>
+        <p><strong>Execution:</strong> Enter on confirmed breakout with volume surge or closing basis; add on pullbacks.</p>
+        <p><strong>Risk:</strong> Initial stop below breakout level, trail aggressively to protect gains.</p>
+        <p><strong>Notes:</strong> Track win rate by session time; avoid chasing extended breakouts.</p>
+      </article>
+      <article class="strategy">
+        <h3>4. News/Event Reaction</h3>
+        <p><strong>Market context:</strong> Scheduled events (FOMC, CPI, exchange listings) create volatility spikes.</p>
+        <p><strong>Execution:</strong> Wait for initial impulse to settle, then trade pullback toward key levels with tight risk.</p>
+        <p><strong>Risk:</strong> Use reduced size; slippage is high. Cancel trade if spread widens drastically.</p>
+        <p><strong>Notes:</strong> Log event specifics to refine filters (e.g., only trade positive surprises).</p>
+      </article>
+    </section>
+
+    <section id="journal" class="card">
+      <h2>Trading Journal Template</h2>
+      <p>Duplicate this table for every trading day. Attach screenshots of charts at entry and exit for visual review.</p>
+      <div class="table-wrapper">
+        <table>
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Asset</th>
+              <th>Setup / Strategy</th>
+              <th>Bias &amp; Thesis</th>
+              <th>Entry</th>
+              <th>Stop</th>
+              <th>Targets</th>
+              <th>Position Size</th>
+              <th>Result (R / %)</th>
+              <th>Execution Notes</th>
+              <th>Emotion / State</th>
+              <th>Improvements</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>2024-03-01</td>
+              <td>BTC/USDT</td>
+              <td>Trend Continuation</td>
+              <td>Retest of 4H support aligned with daily uptrend</td>
+              <td>51,200</td>
+              <td>50,400</td>
+              <td>52,800 / 54,000</td>
+              <td>1.5%</td>
+              <td>+2.3R</td>
+              <td>Entered on retest with bullish engulfing</td>
+              <td>Focused, calm</td>
+              <td>Consider partials at 1.5R</td>
+            </tr>
+            <tr>
+              <td>2024-03-01</td>
+              <td>ETH/USDT</td>
+              <td>Range Reversion</td>
+              <td>Fade top of hourly range with bearish divergence</td>
+              <td>3,320</td>
+              <td>3,360</td>
+              <td>3,260</td>
+              <td>1%</td>
+              <td>-1.0R</td>
+              <td>Entry too early; signal not confirmed</td>
+              <td>Anxious</td>
+              <td>Wait for candle close confirmation</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section id="metrics" class="card">
+      <h2>Performance Metrics Dashboard</h2>
+      <div class="grid three">
+        <div class="metric">
+          <h3>Key Ratios</h3>
+          <ul>
+            <li>Win Rate</li>
+            <li>Average R Multiple</li>
+            <li>Expectancy (R)</li>
+            <li>Max Drawdown</li>
+            <li>Sharpe / Sortino (weekly)</li>
+          </ul>
+        </div>
+        <div class="metric">
+          <h3>Risk Controls</h3>
+          <ul>
+            <li>Daily Loss Limit: -3R</li>
+            <li>Weekly Loss Limit: -7R</li>
+            <li>Max Concurrent Positions: 3</li>
+            <li>Leverage Cap: 3x average</li>
+            <li>Capital at Risk &lt; 6% total</li>
+          </ul>
+        </div>
+        <div class="metric">
+          <h3>Improvement Focus</h3>
+          <ul>
+            <li>Tag-based performance heatmap</li>
+            <li>Session performance (Asia, EU, US)</li>
+            <li>Mistake log vs. rule violations</li>
+            <li>Execution grade (A/B/C)</li>
+            <li>Mental state correlations</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section id="review" class="card">
+      <h2>Weekly Review Checklist</h2>
+      <ol>
+        <li>Summarize weekly PnL and expectancy per strategy.</li>
+        <li>Identify best and worst trade &mdash; focus on process, not outcome.</li>
+        <li>Review screenshots and note recurring patterns.</li>
+        <li>Adjust risk if drawdown exceeds thresholds.</li>
+        <li>Set goals for next week (e.g., reduce overtrading, execute alerts faster).</li>
+      </ol>
+    </section>
+
+    <section id="resources" class="card">
+      <h2>Additional Resources</h2>
+      <ul>
+        <li><strong>Books:</strong> "Trading in the Zone" by Mark Douglas, "The Daily Trading Coach" by Brett Steenbarger.</li>
+        <li><strong>Tools:</strong> TradingView for charting, Coinalyze for futures data, Laevitas for options sentiment.</li>
+        <li><strong>Podcasts:</strong> The Trader's Podcast, Chat With Traders.</li>
+        <li><strong>Education:</strong> Track your trades in Notion/Sheets; review reputable on-chain analytics blogs.</li>
+      </ul>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>Stay disciplined, respect risk, and keep refining your edge. © 2024</p>
+  </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,218 @@
+:root {
+  --bg: #0f172a;
+  --bg-card: rgba(15, 23, 42, 0.85);
+  --accent: #38bdf8;
+  --text: #e2e8f0;
+  --muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.2);
+  --shadow: 0 20px 40px rgba(15, 23, 42, 0.45);
+  --font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: var(--font-body);
+  background: linear-gradient(135deg, #020617, #0f172a 40%, #1e293b);
+  color: var(--text);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+.hero {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  min-height: 50vh;
+  background: url('https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=1600&q=80') center/cover no-repeat;
+  overflow: hidden;
+}
+
+.hero__overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.95), rgba(2, 132, 199, 0.4));
+}
+
+.hero__content {
+  position: relative;
+  max-width: 720px;
+  padding: 3rem 1.5rem;
+}
+
+.hero h1 {
+  font-size: clamp(2.8rem, 5vw, 3.8rem);
+  margin-bottom: 1rem;
+}
+
+.hero p {
+  font-size: 1.15rem;
+  color: var(--muted);
+}
+
+.btn {
+  display: inline-block;
+  margin-top: 2rem;
+  padding: 0.85rem 2.5rem;
+  background: var(--accent);
+  color: #0f172a;
+  border-radius: 999px;
+  font-weight: 600;
+  text-decoration: none;
+  box-shadow: var(--shadow);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 30px rgba(56, 189, 248, 0.35);
+}
+
+.nav {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 1.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  border-bottom: 1px solid var(--border);
+}
+
+.nav a {
+  color: var(--muted);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 0.4rem 0.8rem;
+  transition: color 0.2s ease, transform 0.2s ease;
+}
+
+.nav a:hover {
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+main {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 2.5rem;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(12px);
+}
+
+.card h2 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+}
+
+.card p,
+.card li {
+  color: var(--muted);
+}
+
+.card ul,
+.card ol {
+  margin-left: 1.25rem;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.grid.two {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+}
+
+.grid.three {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.strategy + .strategy {
+  margin-top: 2rem;
+}
+
+.strategy h3 {
+  margin-bottom: 0.75rem;
+  color: var(--accent);
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 720px;
+}
+
+thead th {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-align: left;
+  padding-bottom: 0.75rem;
+  border-bottom: 1px solid var(--border);
+}
+
+tbody td {
+  padding: 0.75rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.metric {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: var(--shadow);
+}
+
+.metric h3 {
+  margin-bottom: 1rem;
+  color: var(--accent);
+}
+
+.footer {
+  text-align: center;
+  padding: 2rem 1rem 3rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 640px) {
+  .card {
+    padding: 1.75rem;
+  }
+
+  .hero {
+    min-height: 60vh;
+  }
+
+  .nav {
+    gap: 0.5rem;
+    padding: 1rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a landing page that outlines core trading mindset, routines, and strategy guidance
- include a rich trading journal template with performance metrics and review checklists
- style the page with a modern dark theme suitable for crypto trading content

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d717ad966c833190692445251aa3f4